### PR TITLE
Restored stream pub visibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod handshake;
     feature = "async-native-tls",
     feature = "tokio-tls",
 ))]
-mod stream;
+pub mod stream;
 
 use std::io::{Read, Write};
 


### PR DESCRIPTION
Hi @sdroege 

I'm not sure this is the correct way. 

Pre 0.3 i used the `async_tungstenite::stream::Stream` enum for `Plan/TLS` websocket. 
Is that still valid or there is another way to store it in custom struct?. 

Thanks

