### PR TITLE
Fix warning for gio link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # async-tungstenite
 
 Asynchronous WebSockets for [async-std](https://async.rs),
-[tokio](https://tokio.rs), [gio](https://www.gtk-rs.org) and any `std`
+[tokio](https://tokio.rs), [gio](https://gtk-rs.org) and any `std`
 `Future`s runtime.
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ integration with various other crates can be enabled via feature flags
  * `tokio-tls`: Enables the additional functions in the `tokio` module to
    implement TLS via [tokio-tls](https://crates.io/crates/tokio-tls).
  * `gio-runtime`: Enables the `gio` module, which provides integration with
-   the [gio](https://www.gtk-rs.org) runtime.
+   the [gio](https://gtk-rs.org) runtime.
 
 ## tokio-tungstenite
 


### PR DESCRIPTION
I have a warning with `https://www.gtk-rs.org/`, but `https://gtk-rs.org/` seems to work fine. Getting the same result in different browsers