### PR TITLE
build(deps): minimize unnecessary dependencies by using `futures-{cha…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "a
 
 [dependencies]
 log = "0.4"
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
+futures-io = { version = "0.3", default-features = false }
 pin-project = "0.4"
 
 [dependencies.tungstenite]
@@ -71,6 +72,7 @@ optional = true
 version = "0.9"
 
 [dev-dependencies]
+futures = "0.3"
 url = "2.0.0"
 env_logger = "0.7"
 async-std = { version = "1.0", features = ["attributes", "unstable"] }

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -1,5 +1,5 @@
 use async_tungstenite::{async_std::connect_async, tungstenite::Error, tungstenite::Result};
-use futures::{SinkExt, StreamExt};
+use futures::prelude::*;
 use log::*;
 
 const AGENT: &str = "Tungstenite";

--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -1,6 +1,6 @@
 use async_std::net::{SocketAddr, TcpListener, TcpStream};
 use async_tungstenite::{accept_async, tungstenite::Error};
-use futures::{SinkExt, StreamExt};
+use futures::prelude::*;
 use log::*;
 use tungstenite::Result;
 

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -12,7 +12,7 @@ use std::{env, io::Error};
 
 use async_std::net::{TcpListener, TcpStream};
 use async_std::task;
-use futures::StreamExt;
+use futures::prelude::*;
 use log::info;
 
 async fn run() -> Result<(), Error> {

--- a/examples/interval-server.rs
+++ b/examples/interval-server.rs
@@ -2,7 +2,7 @@ use async_std::net::{TcpListener, TcpStream};
 use async_std::task;
 use async_tungstenite::{accept_async, tungstenite::Error};
 use futures::future::{select, Either};
-use futures::{SinkExt, StreamExt};
+use futures::prelude::*;
 use log::*;
 use std::net::SocketAddr;
 use std::time::Duration;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -25,11 +25,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use futures::prelude::*;
 use futures::{
     channel::mpsc::{unbounded, UnboundedSender},
     future, pin_mut,
-    stream::TryStreamExt,
-    StreamExt,
 };
 
 use async_std::net::{TcpListener, TcpStream};

--- a/src/async_std.rs
+++ b/src/async_std.rs
@@ -9,7 +9,7 @@ use async_std::net::TcpStream;
 use super::{domain, port, WebSocketStream};
 
 #[cfg(feature = "async-native-tls")]
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "async-native-tls")]
 pub(crate) mod async_native_tls {
@@ -22,7 +22,7 @@ pub(crate) mod async_native_tls {
     use tungstenite::stream::Mode;
     use tungstenite::Error;
 
-    use futures::io::{AsyncRead, AsyncWrite};
+    use futures_io::{AsyncRead, AsyncWrite};
 
     use crate::stream::Stream as StreamSwitcher;
     use crate::{
@@ -93,7 +93,7 @@ pub(crate) mod async_native_tls {
 
 #[cfg(not(any(feature = "async-tls", feature = "async-native-tls")))]
 pub(crate) mod dummy_tls {
-    use futures::io::{AsyncRead, AsyncWrite};
+    use futures_io::{AsyncRead, AsyncWrite};
 
     use tungstenite::client::{uri_mode, IntoClientRequest};
     use tungstenite::handshake::client::Request;

--- a/src/async_tls.rs
+++ b/src/async_tls.rs
@@ -4,7 +4,7 @@ use tungstenite::handshake::client::{Request, Response};
 use tungstenite::protocol::WebSocketConfig;
 use tungstenite::Error;
 
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 
 use super::{client_async_with_config, WebSocketStream};
 

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -3,8 +3,8 @@ use std::io::{Read, Write};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::task;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::task;
 use std::sync::Arc;
 use tungstenite::Error as WsError;
 

--- a/src/gio.rs
+++ b/src/gio.rs
@@ -5,7 +5,7 @@ use std::io;
 
 use gio::prelude::*;
 
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 
 use tungstenite::client::{uri_mode, IntoClientRequest};
 use tungstenite::handshake::client::Request;

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -1,6 +1,6 @@
 use crate::compat::{AllowStd, SetWaker};
 use crate::WebSocketStream;
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 use log::*;
 use std::future::Future;
 use std::io::{Read, Write};
@@ -148,7 +148,11 @@ where
     type Output = Result<Role::FinalResult, Error<Role>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut s = self.as_mut().0.take().expect("future polled after completion");
+        let mut s = self
+            .as_mut()
+            .0
+            .take()
+            .expect("future polled after completion");
 
         let machine = s.get_mut();
         trace!("Setting context in handshake");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@
     unused_imports,
     unused_import_braces
 )]
-
 #![forbid(unsafe_code)]
 
 pub use tungstenite;
@@ -49,8 +48,11 @@ pub mod stream;
 use std::io::{Read, Write};
 
 use compat::{cvt, AllowStd, ContextWaker};
-use futures::io::{AsyncRead, AsyncWrite};
-use futures::{Sink, SinkExt, Stream};
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{
+    sink::{Sink, SinkExt},
+    stream::Stream,
+};
 use log::*;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -283,7 +285,7 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         trace!("{}:{} Stream.poll_next", file!(), line!());
-        match futures::ready!(self.with_context(Some((ContextWaker::Read, cx)), |s| {
+        match futures_util::ready!(self.with_context(Some((ContextWaker::Read, cx)), |s| {
             trace!(
                 "{}:{} Stream.with_context poll_next -> read_message()",
                 file!(),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,7 +6,7 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 
 /// Stream, either plain TCP or TLS.
 pub enum Stream<S, T> {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -8,7 +8,7 @@ use tokio::net::TcpStream;
 
 use super::{domain, port, WebSocketStream};
 
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "tokio-tls")]
 pub(crate) mod tokio_tls {
@@ -20,7 +20,7 @@ pub(crate) mod tokio_tls {
     use tungstenite::stream::Mode;
     use tungstenite::Error;
 
-    use futures::io::{AsyncRead, AsyncWrite};
+    use futures_io::{AsyncRead, AsyncWrite};
 
     use crate::stream::Stream as StreamSwitcher;
     use crate::{client_async_with_config, domain, Response, WebSocketConfig, WebSocketStream};
@@ -91,7 +91,7 @@ pub(crate) mod tokio_tls {
 
 #[cfg(not(any(feature = "async-tls", feature = "tokio-tls")))]
 pub(crate) mod dummy_tls {
-    use futures::io::{AsyncRead, AsyncWrite};
+    use futures_io::{AsyncRead, AsyncWrite};
 
     use tungstenite::client::{uri_mode, IntoClientRequest};
     use tungstenite::handshake::client::Request;

--- a/tests/communication.rs
+++ b/tests/communication.rs
@@ -1,7 +1,7 @@
 use async_std::net::{TcpListener, TcpStream};
 use async_std::task;
 use async_tungstenite::{accept_async, client_async, WebSocketStream};
-use futures::{AsyncRead, AsyncWrite, SinkExt, StreamExt};
+use futures::prelude::*;
 use log::*;
 use tungstenite::Message;
 


### PR DESCRIPTION
…nnel,io,util}` directly instead of `futures` outside of tests/examples