### PR TITLE
Expose the configuration of the websocket connection.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,12 @@ impl<S> WebSocketStream<S> {
         self.inner.get_mut().get_mut()
     }
 
+    /// Returns a reference to the configuration of the tungstenite stream.
+    pub fn get_config(&self) -> &WebSocketConfig
+    {
+        self.inner.get_config()
+    }
+
     /// Close the underlying web socket
     pub async fn close(&mut self, msg: Option<CloseFrame<'_>>) -> Result<(), WsError>
     where


### PR DESCRIPTION
Allows wrapper types to respect max_message_size. This was only just merged into tungstenite (snapview/tungstenite-rs#112), so it won't work until they release a new version. 