### PR TITLE
Update chat example to not broadcast close

### DIFF
--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -2,11 +2,11 @@
 //!
 //! You can test this out by running:
 //!
-//!     cargo run --example server 127.0.0.1:12345
+//!     cargo run --features="async-std-runtime" --example echo-server 127.0.0.1:12345
 //!
 //! And then in another window run:
 //!
-//!     cargo run --example client ws://127.0.0.1:12345/
+//!     cargo run --features="async-std-runtime" --example client ws://127.0.0.1:12345/
 
 use std::{env, io::Error};
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -6,11 +6,11 @@
 //!
 //! You can test this out by running:
 //!
-//!     cargo run --example server 127.0.0.1:12345
+//!     cargo run --features="async-std-runtime" --example server 127.0.0.1:12345
 //!
 //! And then in another window run:
 //!
-//!     cargo run --example client ws://127.0.0.1:12345/
+//!     cargo run --features="async-std-runtime" --example client ws://127.0.0.1:12345/
 //!
 //! You can run the second command in multiple windows and then chat between the
 //! two, seeing the messages from the other client as they're received. For all


### PR DESCRIPTION
**This PR**
1. Updates the commands in `examples/server.rs` to pass the `--features="async-std-runtime"` flag
1. Updates the commands in `examples/echo-server.rs` to pass the `--features="async-std-runtime"` flag
1. Updates the command in `examples/echo-server.rs` to start the `echo-server` example instead of the `server` example
1. Updates the server example to not broadcast `Close` messages

**Why?**
First two are because, when running the commands without the features flag, you get an error:
```
error: target `server` in package `async-tungstenite` requires the features: `async-std-runtime`
Consider enabling them by passing, e.g., `--features="async-std-runtime"`
```
Third one is so the command starts the example that it's written in - probably just fixing a copy-paste typo.
Last one is because, if clients send a `Close` message to the server, it's broadcast to the other clients, closing their connections (potentially) prematurely.

Tracking issue https://github.com/sdroege/async-tungstenite/issues/22