### PR TITLE
Don't declare internal port function when only the async-tls feature …

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,7 +371,6 @@ pub(crate) fn domain(
 }
 
 #[cfg(any(
-    feature = "async-tls",
     feature = "async-std-runtime",
     feature = "tokio-runtime",
     feature = "gio-runtime"


### PR DESCRIPTION
…is enabled

warning: function is never used: `port`
   --> src/lib.rs:381:15
    |
381 | pub(crate) fn port(
    |               ^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: 1 warning emitted