### PR TITLE
Add support for tokio-rustls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   - cargo check --features async-std-runtime,async-tls,async-native-tls
   - cargo check --features tokio-runtime,async-tls
   - cargo check --features tokio-runtime,tokio-native-tls
+  - cargo check --features tokio-runtime,tokio-rustls
   - cargo check --features tokio-runtime,tokio-openssl
   - cargo check --features tokio-runtime,async-tls,tokio-native-tls
   - cargo check --features gio-runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,18 @@ edition = "2018"
 readme = "README.md"
 
 [features]
-default = []
+default = ["tokio-rustls"]
 async-std-runtime = ["async-std"]
 tokio-runtime = ["tokio"]
 gio-runtime = ["gio", "glib"]
 async-tls = ["real-async-tls"]
 async-native-tls = ["async-std-runtime", "real-async-native-tls"]
 tokio-native-tls = ["tokio-runtime", "real-tokio-native-tls", "real-native-tls", "tungstenite/tls"]
+tokio-rustls = ["tokio-runtime", "real-tokio-rustls", "tungstenite/tls"]
 tokio-openssl = ["tokio-runtime", "real-tokio-openssl", "openssl"]
 
 [package.metadata.docs.rs]
-features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "async-native-tls", "tokio-native-tls"]
+features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "async-native-tls", "tokio-native-tls", "tokio-rustls"]
 
 [dependencies]
 log = "0.4"
@@ -72,6 +73,11 @@ features = ["tcp", "dns"]
 optional = true
 version = "0.1"
 package = "tokio-native-tls"
+
+[dependencies.real-tokio-rustls]
+optional = true
+version = "^0.14"
+package = "tokio-rustls"
 
 [dependencies.gio]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2018"
 readme = "README.md"
 
 [features]
-default = ["tokio-rustls"]
+default = []
 async-std-runtime = ["async-std"]
 tokio-runtime = ["tokio"]
 gio-runtime = ["gio", "glib"]
 async-tls = ["real-async-tls"]
 async-native-tls = ["async-std-runtime", "real-async-native-tls"]
 tokio-native-tls = ["tokio-runtime", "real-tokio-native-tls", "real-native-tls", "tungstenite/tls"]
-tokio-rustls = ["tokio-runtime", "real-tokio-rustls", "tungstenite/tls"]
+tokio-rustls = ["tokio-runtime", "real-tokio-rustls"]
 tokio-openssl = ["tokio-runtime", "real-tokio-openssl", "openssl"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ integration with various other crates can be enabled via feature flags
    with the [tokio](https://tokio.rs) runtime.
  * `tokio-native-tls`: Enables the additional functions in the `tokio` module to
    implement TLS via [tokio-native-tls](https://crates.io/crates/tokio-native-tls).
+ * `tokio-rustls`: Enables the additional functions in the `tokio` module to
+   implement TLS via [tokio-rustls](https://crates.io/crates/tokio-rustls).
  * `gio-runtime`: Enables the `gio` module, which provides integration with
    the [gio](https://gtk-rs.org) runtime.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 //!    with the [tokio](https://tokio.rs) runtime.
 //!  * `tokio-native-tls`: Enables the additional functions in the `tokio` module to
 //!    implement TLS via [tokio-native-tls](https://crates.io/crates/tokio-native-tls).
+//!  * `tokio-rustls`: Enables the additional functions in the `tokio` module to
+//!    implement TLS via [tokio-rustls](https://crates.io/crates/tokio-rustls).
 //!  * `tokio-openssl`: Enables the additional functions in the `tokio` module to
 //!    implement TLS via [tokio-openssl](https://crates.io/crates/tokio-openssl).
 //!  * `gio-runtime`: Enables the `gio` module, which provides integration with
@@ -43,6 +45,7 @@ mod handshake;
     feature = "async-tls",
     feature = "async-native-tls",
     feature = "tokio-native-tls",
+    feature = "tokio-rustls",
     feature = "tokio-openssl",
 ))]
 pub mod stream;


### PR DESCRIPTION
This PR will add support for using `tokio-rustls` bindings. Implementation follows the way of `tokio-native-tls` bindings.