### PR TITLE
Update async-tls to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ version = "0.10"
 
 [dependencies.real-async-tls]
 optional = true
-version = "0.9"
+version = "0.10"
 package = "async-tls"
 
 [dependencies.real-async-native-tls]


### PR DESCRIPTION
This will reduce dependencies with a finer-grained use of the futures crates by async-tls (async-rs/async-tls#31)