### PR TITLE
Add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,12 @@ jobs:
           sudo apt-get install python-unittest2
           sudo pip install urllib3[secure] autobahntestsuite
 
+      - name: Build Autobahn TestSuite for client
+        run: cargo build --release --features async-std-runtime --example autobahn-client
+
+      - name: Build Autobahn TestSuite for server
+        run: cargo build --release --features async-std-runtime --example autobahn-server
+
       - name: Running Autobahn TestSuite for client
         run: ./scripts/autobahn-client.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,23 +30,47 @@ jobs:
           sudo apt-get install libssl-dev python-unittest2
           sudo pip install urllib3[secure] autobahntestsuite
 
-      - run: cargo check
-      - run: cargo check --features async-tls
-      - run: cargo check --features async-std-runtime,async-tls
-      - run: cargo check --features async-std-runtime,async-native-tls
-      - run: cargo check --features async-std-runtime,async-tls,async-native-tls
+      - name: Check default-features
+        run: cargo check
 
-      - run: cargo check --features tokio-runtime,tokio-native-tls
-      - run: cargo check --features tokio-runtime,tokio-rustls
-      - run: cargo check --features tokio-runtime,tokio-openssl
-      - run: cargo check --features tokio-runtime,async-tls,tokio-native-tls
+      - name: Check async-tls
+        run: cargo check --features async-tls
 
-      - run: cargo check --features gio-runtime
-      - run: cargo check --features gio-runtime,async-tls
+      - name: Check async-std-runtime, async-tls
+        run: cargo check --features async-std-runtime,async-tls
 
-      - run: cargo check --features async-std-runtime,async-tls,async-native-tls,tokio-runtime,tokio-native-tls,gio-runtime
+      - name: Check async-std-runtime, async-native-tls
+        run: cargo check --features async-std-runtime,async-native-tls
 
-      - run: cargo test --features async-std-runtime
+      - name: Check async-std-runtime, async-tls, async-native-tls
+        run: cargo check --features async-std-runtime,async-tls,async-native-tls
 
-      - run: echo "Running Autobahn TestSuite for client" && ./scripts/autobahn-client.sh
-      - run: echo "Running Autobahn TestSuite for server" && ./scripts/autobahn-server.sh
+      - name: Check tokio-runtime, tokio-native-tls
+        run: cargo check --features tokio-runtime,tokio-native-tls
+
+      - name: Check tokio-runtime, tokio-rustls
+        run: cargo check --features tokio-runtime,tokio-rustls
+
+      - name: Check tokio-runtime, tokio-openssl
+        run: cargo check --features tokio-runtime,tokio-openssl
+
+      - name: Check tokio-runtime, async-tls, tokio-native-tls
+        run: cargo check --features tokio-runtime,async-tls,tokio-native-tls
+
+      - name: Check gio-runtime
+        run: cargo check --features gio-runtime
+
+      - name: Check gio-runtime, async-tls
+        run: cargo check --features gio-runtime,async-tls
+
+      - name: Check async-std-runtime, async-tls, async-native-tls, tokio-runtime, tokio-native-tls, gio-runtime
+        run: cargo check --features async-std-runtime,async-tls,async-native-tls,tokio-runtime,tokio-native-tls,gio-runtime
+
+      - name: Test async-std-runtime
+        run: cargo test --features async-std-runtime
+
+      - name: Running Autobahn TestSuite for client
+        run: ./scripts/autobahn-client.sh
+
+      - name: Running Autobahn TestSuite for server
+        run: ./scripts/autobahn-server.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,33 @@ jobs:
       - name: Test async-std-runtime
         run: cargo test --features async-std-runtime
 
+  autobahn:
+    name: Autobahn tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install python-unittest2
+          sudo pip install urllib3[secure] autobahntestsuite
+
       - name: Running Autobahn TestSuite for client
         run: ./scripts/autobahn-client.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install libssl-dev python-unittest2
-          sudo pip install urllib3[secure] autobahntestsuite
+          sudo apt-get install libssl-dev
 
       - name: Check default-features
         run: cargo check
@@ -93,7 +92,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install python-unittest2
+          sudo apt-get install libssl-dev python-unittest2
           sudo pip install urllib3[secure] autobahntestsuite
 
       - name: Build Autobahn TestSuite for client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install libssl-dev python-unittest2
+          sudo pip install urllib3[secure] autobahntestsuite
+
+      - run: cargo check
+      - run: cargo check --features async-tls
+      - run: cargo check --features async-std-runtime,async-tls
+      - run: cargo check --features async-std-runtime,async-native-tls
+      - run: cargo check --features async-std-runtime,async-tls,async-native-tls
+
+      - run: cargo check --features tokio-runtime,tokio-native-tls
+      - run: cargo check --features tokio-runtime,tokio-rustls
+      - run: cargo check --features tokio-runtime,tokio-openssl
+      - run: cargo check --features tokio-runtime,async-tls,tokio-native-tls
+
+      - run: cargo check --features gio-runtime
+      - run: cargo check --features gio-runtime,async-tls
+
+      - run: cargo check --features async-std-runtime,async-tls,async-native-tls,tokio-runtime,tokio-native-tls,gio-runtime
+
+      - run: cargo test --features async-std-runtime
+
+      - run: echo "Running Autobahn TestSuite for client" && ./scripts/autobahn-client.sh
+      - run: echo "Running Autobahn TestSuite for server" && ./scripts/autobahn-server.sh


### PR DESCRIPTION
I converted the travis config to GitHub Actions and optimized it by split out the Autobahn testsuite into separated build jobs