### PR TITLE
Remove the tokio-rustls feature from the docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio-rustls = ["tokio-runtime", "real-tokio-rustls"]
 tokio-openssl = ["tokio-runtime", "real-tokio-openssl", "openssl"]
 
 [package.metadata.docs.rs]
-features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "async-native-tls", "tokio-native-tls", "tokio-rustls"]
+features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "async-native-tls", "tokio-native-tls"]
 
 [dependencies]
 log = "0.4"


### PR DESCRIPTION
the tokio tls features don't play nice together at the moment
and break the doc build

see: https://docs.rs/crate/async-tungstenite/0.9.0/builds/302643