### PR TITLE
Update tokio to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 homepage = "https://github.com/sdroege/async-tungstenite"
 repository = "https://github.com/sdroege/async-tungstenite"
 documentation = "https://docs.rs/async-tungstenite"
-version = "0.9.3"
+version = "0.10.0"
 edition = "2018"
 readme = "README.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version = "1.0"
 
 [dependencies.real-tokio-openssl]
 optional = true
-version = "0.4"
+version = "0.5"
 package = "tokio-openssl"
 
 [dependencies.openssl]
@@ -66,17 +66,17 @@ package = "native-tls"
 
 [dependencies.tokio]
 optional = true
-version = "0.2"
-features = ["tcp", "dns"]
+version = "0.3"
+features = ["net"]
 
 [dependencies.real-tokio-native-tls]
 optional = true
-version = "0.1"
+version = "0.2"
 package = "tokio-native-tls"
 
 [dependencies.real-tokio-rustls]
 optional = true
-version = "^0.14"
+version = "^0.20"
 package = "tokio-rustls"
 
 [dependencies.webpki-roots]

--- a/src/tokio/async_tls.rs
+++ b/src/tokio/async_tls.rs
@@ -1,6 +1,19 @@
-use super::{Error, IntoClientRequest, Response, TokioAdapter, WebSocketConfig, WebSocketStream};
+use real_async_tls::client::TlsStream;
+use real_async_tls::TlsConnector;
+
+use tungstenite::client::IntoClientRequest;
+use tungstenite::Error;
+
 use crate::stream::Stream as StreamSwitcher;
-use std::marker::Unpin;
+use crate::{Response, WebSocketConfig, WebSocketStream};
+
+use super::TokioAdapter;
+
+pub type MaybeTlsStream<S> = StreamSwitcher<S, TlsStream<S>>;
+
+pub type AutoStream<S> = MaybeTlsStream<TokioAdapter<S>>;
+
+pub type Connector = TlsConnector;
 
 /// Creates a WebSocket handshake from a request and a stream,
 /// upgrading the stream to TLS if required and using the given
@@ -24,9 +37,3 @@ where
     )
     .await
 }
-
-pub type Connector = real_async_tls::TlsConnector;
-
-pub type MaybeTlsStream<S> = StreamSwitcher<S, real_async_tls::client::TlsStream<S>>;
-
-pub type AutoStream<S> = MaybeTlsStream<TokioAdapter<S>>;

--- a/src/tokio/async_tls.rs
+++ b/src/tokio/async_tls.rs
@@ -1,0 +1,32 @@
+use super::{Error, IntoClientRequest, Response, TokioAdapter, WebSocketConfig, WebSocketStream};
+use crate::stream::Stream as StreamSwitcher;
+use std::marker::Unpin;
+
+/// Creates a WebSocket handshake from a request and a stream,
+/// upgrading the stream to TLS if required and using the given
+/// connector and WebSocket configuration.
+pub async fn client_async_tls_with_connector_and_config<R, S>(
+    request: R,
+    stream: S,
+    connector: Option<Connector>,
+    config: Option<WebSocketConfig>,
+) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+    S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    AutoStream<S>: Unpin,
+{
+    crate::async_tls::client_async_tls_with_connector_and_config(
+        request,
+        TokioAdapter(stream),
+        connector,
+        config,
+    )
+    .await
+}
+
+pub type Connector = real_async_tls::TlsConnector;
+
+pub type MaybeTlsStream<S> = StreamSwitcher<S, real_async_tls::client::TlsStream<S>>;
+
+pub type AutoStream<S> = MaybeTlsStream<TokioAdapter<S>>;

--- a/src/tokio/dummy_tls.rs
+++ b/src/tokio/dummy_tls.rs
@@ -1,0 +1,49 @@
+use tungstenite::client::{uri_mode, IntoClientRequest};
+use tungstenite::handshake::client::Request;
+use tungstenite::stream::Mode;
+use tungstenite::Error;
+
+use super::TokioAdapter;
+
+use crate::{client_async_with_config, domain, Response, WebSocketConfig, WebSocketStream};
+
+pub type AutoStream<S> = TokioAdapter<S>;
+
+type Connector = ();
+
+async fn wrap_stream<S>(
+    socket: S,
+    _domain: String,
+    _connector: Option<()>,
+    mode: Mode,
+) -> Result<AutoStream<S>, Error>
+where
+    S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    match mode {
+        Mode::Plain => Ok(TokioAdapter(socket)),
+        Mode::Tls => Err(Error::Url("TLS support not compiled in.".into())),
+    }
+}
+
+pub(crate) async fn client_async_tls_with_connector_and_config<R, S>(
+    request: R,
+    stream: S,
+    connector: Option<Connector>,
+    config: Option<WebSocketConfig>,
+) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+    S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    AutoStream<S>: Unpin,
+{
+    let request: Request = request.into_client_request()?;
+
+    let domain = domain(&request)?;
+
+    // Make sure we check domain and mode first. URL must be valid.
+    let mode = uri_mode(request.uri())?;
+
+    let stream = wrap_stream(stream, domain, connector, mode).await?;
+    client_async_with_config(request, stream, config).await
+}

--- a/src/tokio/native_tls.rs
+++ b/src/tokio/native_tls.rs
@@ -1,0 +1,73 @@
+use real_tokio_native_tls::TlsConnector as AsyncTlsConnector;
+use real_tokio_native_tls::TlsStream;
+
+use tungstenite::client::{uri_mode, IntoClientRequest};
+use tungstenite::handshake::client::Request;
+use tungstenite::stream::Mode;
+use tungstenite::Error;
+
+use crate::stream::Stream as StreamSwitcher;
+use crate::{client_async_with_config, domain, Response, WebSocketConfig, WebSocketStream};
+
+use super::TokioAdapter;
+
+/// A stream that might be protected with TLS.
+pub type MaybeTlsStream<S> = StreamSwitcher<TokioAdapter<S>, TokioAdapter<TlsStream<S>>>;
+
+pub type AutoStream<S> = MaybeTlsStream<S>;
+
+pub type Connector = AsyncTlsConnector;
+
+async fn wrap_stream<S>(
+    socket: S,
+    domain: String,
+    connector: Option<Connector>,
+    mode: Mode,
+) -> Result<AutoStream<S>, Error>
+where
+    S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    match mode {
+        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter(socket))),
+        Mode::Tls => {
+            let stream = {
+                let connector = if let Some(connector) = connector {
+                    connector
+                } else {
+                    let connector = real_native_tls::TlsConnector::builder().build()?;
+                    AsyncTlsConnector::from(connector)
+                };
+                connector
+                    .connect(&domain, socket)
+                    .await
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
+            };
+            Ok(StreamSwitcher::Tls(TokioAdapter(stream)))
+        }
+    }
+}
+
+/// Creates a WebSocket handshake from a request and a stream,
+/// upgrading the stream to TLS if required and using the given
+/// connector and WebSocket configuration.
+pub async fn client_async_tls_with_connector_and_config<R, S>(
+    request: R,
+    stream: S,
+    connector: Option<AsyncTlsConnector>,
+    config: Option<WebSocketConfig>,
+) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+    S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    AutoStream<S>: Unpin,
+{
+    let request: Request = request.into_client_request()?;
+
+    let domain = domain(&request)?;
+
+    // Make sure we check domain and mode first. URL must be valid.
+    let mode = uri_mode(request.uri())?;
+
+    let stream = wrap_stream(stream, domain, connector, mode).await?;
+    client_async_with_config(request, stream, config).await
+}

--- a/src/tokio/openssl.rs
+++ b/src/tokio/openssl.rs
@@ -1,0 +1,88 @@
+use openssl::ssl::{ConnectConfiguration, SslConnector, SslMethod};
+use real_tokio_openssl::connect;
+use real_tokio_openssl::SslStream as TlsStream;
+
+use tungstenite::client::{uri_mode, IntoClientRequest};
+use tungstenite::handshake::client::Request;
+use tungstenite::stream::Mode;
+use tungstenite::Error;
+
+use crate::stream::Stream as StreamSwitcher;
+use crate::{client_async_with_config, domain, Response, WebSocketConfig, WebSocketStream};
+
+use super::TokioAdapter;
+
+/// A stream that might be protected with TLS.
+pub type MaybeTlsStream<S> = StreamSwitcher<TokioAdapter<S>, TokioAdapter<TlsStream<S>>>;
+
+pub type AutoStream<S> = MaybeTlsStream<S>;
+
+pub type Connector = ConnectConfiguration;
+
+async fn wrap_stream<S>(
+    socket: S,
+    domain: String,
+    connector: Option<Connector>,
+    mode: Mode,
+) -> Result<AutoStream<S>, Error>
+where
+    S: 'static
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Unpin
+        + std::fmt::Debug
+        + Send
+        + Sync,
+{
+    match mode {
+        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter(socket))),
+        Mode::Tls => {
+            let stream = {
+                let connector = if let Some(connector) = connector {
+                    connector
+                } else {
+                    SslConnector::builder(SslMethod::tls_client())
+                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
+                        .build()
+                        .configure()
+                        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
+                };
+                connect(connector, &domain, socket)
+                    .await
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
+            };
+            Ok(StreamSwitcher::Tls(TokioAdapter(stream)))
+        }
+    }
+}
+
+/// Creates a WebSocket handshake from a request and a stream,
+/// upgrading the stream to TLS if required and using the given
+/// connector and WebSocket configuration.
+pub async fn client_async_tls_with_connector_and_config<R, S>(
+    request: R,
+    stream: S,
+    connector: Option<Connector>,
+    config: Option<WebSocketConfig>,
+) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+    S: 'static
+        + tokio::io::AsyncRead
+        + tokio::io::AsyncWrite
+        + Unpin
+        + std::fmt::Debug
+        + Send
+        + Sync,
+    AutoStream<S>: Unpin,
+{
+    let request: Request = request.into_client_request()?;
+
+    let domain = domain(&request)?;
+
+    // Make sure we check domain and mode first. URL must be valid.
+    let mode = uri_mode(request.uri())?;
+
+    let stream = wrap_stream(stream, domain, connector, mode).await?;
+    client_async_with_config(request, stream, config).await
+}

--- a/src/tokio/rustls.rs
+++ b/src/tokio/rustls.rs
@@ -1,0 +1,79 @@
+use real_tokio_rustls::rustls::ClientConfig;
+use real_tokio_rustls::webpki::DNSNameRef;
+use real_tokio_rustls::{client::TlsStream, TlsConnector as AsyncTlsConnector};
+
+use tungstenite::client::{uri_mode, IntoClientRequest};
+use tungstenite::handshake::client::Request;
+use tungstenite::stream::Mode;
+use tungstenite::Error;
+
+use crate::stream::Stream as StreamSwitcher;
+use crate::{client_async_with_config, domain, Response, WebSocketConfig, WebSocketStream};
+
+use super::TokioAdapter;
+
+/// A stream that might be protected with TLS.
+pub type MaybeTlsStream<S> = StreamSwitcher<TokioAdapter<S>, TokioAdapter<TlsStream<S>>>;
+
+pub type AutoStream<S> = MaybeTlsStream<S>;
+
+pub type Connector = AsyncTlsConnector;
+
+async fn wrap_stream<S>(
+    socket: S,
+    domain: String,
+    connector: Option<Connector>,
+    mode: Mode,
+) -> Result<AutoStream<S>, Error>
+where
+    S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    match mode {
+        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter(socket))),
+        Mode::Tls => {
+            let stream = {
+                let connector = if let Some(connector) = connector {
+                    connector
+                } else {
+                    let mut config = ClientConfig::new();
+                    config
+                        .root_store
+                        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+                    AsyncTlsConnector::from(std::sync::Arc::new(config))
+                };
+                let domain = DNSNameRef::try_from_ascii_str(&domain)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+                connector
+                    .connect(domain, socket)
+                    .await
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
+            };
+            Ok(StreamSwitcher::Tls(TokioAdapter(stream)))
+        }
+    }
+}
+
+/// Creates a WebSocket handshake from a request and a stream,
+/// upgrading the stream to TLS if required and using the given
+/// connector and WebSocket configuration.
+pub async fn client_async_tls_with_connector_and_config<R, S>(
+    request: R,
+    stream: S,
+    connector: Option<AsyncTlsConnector>,
+    config: Option<WebSocketConfig>,
+) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+    S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    AutoStream<S>: Unpin,
+{
+    let request: Request = request.into_client_request()?;
+
+    let domain = domain(&request)?;
+
+    // Make sure we check domain and mode first. URL must be valid.
+    let mode = uri_mode(request.uri())?;
+
+    let stream = wrap_stream(stream, domain, connector, mode).await?;
+    client_async_with_config(request, stream, config).await
+}

--- a/src/tokio/rustls.rs
+++ b/src/tokio/rustls.rs
@@ -1,6 +1,6 @@
 use real_tokio_rustls::rustls::ClientConfig;
 use real_tokio_rustls::webpki::DNSNameRef;
-use real_tokio_rustls::{client::TlsStream, TlsConnector as AsyncTlsConnector};
+use real_tokio_rustls::{client::TlsStream, TlsConnector};
 
 use tungstenite::client::{uri_mode, IntoClientRequest};
 use tungstenite::handshake::client::Request;
@@ -17,7 +17,7 @@ pub type MaybeTlsStream<S> = StreamSwitcher<TokioAdapter<S>, TokioAdapter<TlsStr
 
 pub type AutoStream<S> = MaybeTlsStream<S>;
 
-pub type Connector = AsyncTlsConnector;
+pub type Connector = TlsConnector;
 
 async fn wrap_stream<S>(
     socket: S,
@@ -39,7 +39,7 @@ where
                     config
                         .root_store
                         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-                    AsyncTlsConnector::from(std::sync::Arc::new(config))
+                    TlsConnector::from(std::sync::Arc::new(config))
                 };
                 let domain = DNSNameRef::try_from_ascii_str(&domain)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
@@ -59,7 +59,7 @@ where
 pub async fn client_async_tls_with_connector_and_config<R, S>(
     request: R,
     stream: S,
-    connector: Option<AsyncTlsConnector>,
+    connector: Option<Connector>,
     config: Option<WebSocketConfig>,
 ) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
 where


### PR DESCRIPTION
I started on adding support for tokio 0.3 with a set of` tokio03-*` features.

Do you want to maintain tokio 0.2 support for future versions or just update to tokio 0.3?

