### PR TITLE
Configure the server trust anchors for tokio-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 homepage = "https://github.com/sdroege/async-tungstenite"
 repository = "https://github.com/sdroege/async-tungstenite"
 documentation = "https://docs.rs/async-tungstenite"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2018"
 readme = "README.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ gio-runtime = ["gio", "glib"]
 async-tls = ["real-async-tls"]
 async-native-tls = ["async-std-runtime", "real-async-native-tls"]
 tokio-native-tls = ["tokio-runtime", "real-tokio-native-tls", "real-native-tls", "tungstenite/tls"]
-tokio-rustls = ["tokio-runtime", "real-tokio-rustls"]
+tokio-rustls = ["tokio-runtime", "real-tokio-rustls", "webpki-roots"]
 tokio-openssl = ["tokio-runtime", "real-tokio-openssl", "openssl"]
 
 [package.metadata.docs.rs]
@@ -78,6 +78,10 @@ package = "tokio-native-tls"
 optional = true
 version = "^0.14"
 package = "tokio-rustls"
+
+[dependencies.webpki-roots]
+optional = true
+version = "0.20"
 
 [dependencies.gio]
 optional = true

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -50,7 +50,10 @@ pub(crate) mod tokio_tls {
                     let connector = if let Some(connector) = connector {
                         connector
                     } else {
-                        let config = ClientConfig::new();
+                        let mut config = ClientConfig::new();
+                        config
+                            .root_store
+                            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
                         AsyncTlsConnector::from(std::sync::Arc::new(config))
                     };
                     let domain = DNSNameRef::try_from_ascii_str(&domain)


### PR DESCRIPTION
The PR makes the async-tls and tokio-rustls features interchangeable without additional configuration of the tokio-rustls connector.

It would be nice if you could release another 0.9 version with these changes, because cargo's issue with feature activation via dev-dependencies drives my crazy.