### PR TITLE
update to async-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ version = "0.10"
 
 [dependencies.real-async-tls]
 optional = true
-version = "0.10"
+version = "0.11"
 package = "async-tls"
 
 [dependencies.real-async-native-tls]


### PR DESCRIPTION
Just bringing async-tls up to date. doesn't break anything. Keeps me from using two different versions of the library.