### PR TITLE
Migrate from pin-project to pin-project-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "a
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 futures-io = { version = "0.3", default-features = false, features = ["std"] }
-pin-project = "1"
+pin-project-lite = "0.2"
 
 [dependencies.tungstenite]
 version = "0.11.0"

--- a/src/tokio/dummy_tls.rs
+++ b/src/tokio/dummy_tls.rs
@@ -21,7 +21,7 @@ where
     S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     match mode {
-        Mode::Plain => Ok(TokioAdapter(socket)),
+        Mode::Plain => Ok(TokioAdapter::new(socket)),
         Mode::Tls => Err(Error::Url("TLS support not compiled in.".into())),
     }
 }

--- a/src/tokio/native_tls.rs
+++ b/src/tokio/native_tls.rs
@@ -28,7 +28,7 @@ where
     S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     match mode {
-        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter(socket))),
+        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter::new(socket))),
         Mode::Tls => {
             let stream = {
                 let connector = if let Some(connector) = connector {
@@ -42,7 +42,7 @@ where
                     .await
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
             };
-            Ok(StreamSwitcher::Tls(TokioAdapter(stream)))
+            Ok(StreamSwitcher::Tls(TokioAdapter::new(stream)))
         }
     }
 }

--- a/src/tokio/openssl.rs
+++ b/src/tokio/openssl.rs
@@ -34,7 +34,7 @@ where
         + Sync,
 {
     match mode {
-        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter(socket))),
+        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter::new(socket))),
         Mode::Tls => {
             let stream = {
                 let connector = if let Some(connector) = connector {
@@ -54,7 +54,7 @@ where
                 TlsStream::new(ssl, socket)
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
             };
-            Ok(StreamSwitcher::Tls(TokioAdapter(stream)))
+            Ok(StreamSwitcher::Tls(TokioAdapter::new(stream)))
         }
     }
 }

--- a/src/tokio/rustls.rs
+++ b/src/tokio/rustls.rs
@@ -29,7 +29,7 @@ where
     S: 'static + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     match mode {
-        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter(socket))),
+        Mode::Plain => Ok(StreamSwitcher::Plain(TokioAdapter::new(socket))),
         Mode::Tls => {
             let stream = {
                 let connector = if let Some(connector) = connector {
@@ -48,7 +48,7 @@ where
                     .await
                     .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?
             };
-            Ok(StreamSwitcher::Tls(TokioAdapter(stream)))
+            Ok(StreamSwitcher::Tls(TokioAdapter::new(stream)))
         }
     }
 }


### PR DESCRIPTION
`pin-project-lite` does not support tuple structs. So, it's a breaking change because `TokioAdapter` and its inner type is public.  

Is there a reason to have the inner type public?

Closes: #75 