### PR TITLE
add get_{ref,mut} for TokioAdapter

### DIFF
--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -402,6 +402,16 @@ impl<T> TokioAdapter<T> {
     pub fn into_inner(self) -> T {
         self.inner
     }
+
+    /// Get a reference to the underlying value.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the underlying value.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
 }
 
 impl<T: tokio::io::AsyncRead> AsyncRead for TokioAdapter<T> {


### PR DESCRIPTION
This is useful if one e.g. wants to adapt some socket settings with `socket2::SockRef` after calling `connect_async`.

```rust
let (conn, _) = async_tungstenite::tokio::connect_async(req).await?;
let sock = socket2::SockRef::from(match conn.get_ref() {
  Stream::Plain(s) => s.get_ref(),
  Stream::Tls(s) => s.get_ref().get_ref().get_ref().get_ref(),
});
sock.set_tcp_keepalive(&socket2::TcpKeepalive::new().with_time(Duration::from_secs(30)))?;
```

---

Alternatively, one could use the [`Compat` type from tokio-util](https://docs.rs/tokio-util/0.6.4/tokio_util/compat/struct.Compat.html) instead of `TokioAdapter` (reducing code duplicaton), but this would be a breaking change.