### PR TITLE
conditionally disable verbose logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio-native-tls = ["tokio-runtime", "real-tokio-native-tls", "real-native-tls",
 tokio-rustls-webpki-roots = ["tokio-runtime", "real-tokio-rustls", "webpki-roots", "tungstenite/rustls-tls"]
 tokio-rustls-native-certs = ["tokio-runtime", "real-tokio-rustls", "rustls-native-certs", "tungstenite/rustls-tls"]
 tokio-openssl = ["tokio-runtime", "real-tokio-openssl", "openssl"]
+no-verbose-logging = []
 
 [package.metadata.docs.rs]
 features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "async-native-tls", "tokio-native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tokio-native-tls = ["tokio-runtime", "real-tokio-native-tls", "real-native-tls",
 tokio-rustls-webpki-roots = ["tokio-runtime", "real-tokio-rustls", "webpki-roots", "tungstenite/rustls-tls"]
 tokio-rustls-native-certs = ["tokio-runtime", "real-tokio-rustls", "rustls-native-certs", "tungstenite/rustls-tls"]
 tokio-openssl = ["tokio-runtime", "real-tokio-openssl", "openssl"]
-no-verbose-logging = []
+verbose-logging = []
 
 [package.metadata.docs.rs]
 features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "async-native-tls", "tokio-native-tls"]

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -121,6 +121,7 @@ where
     where
         F: FnOnce(&mut Context<'_>, Pin<&mut S>) -> Poll<std::io::Result<R>>,
     {
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("{}:{} AllowStd.with_context", file!(), line!());
         let waker = match kind {
             ContextWaker::Read => task::waker_ref(&self.read_waker_proxy),
@@ -144,8 +145,10 @@ where
     S: AsyncRead + Unpin,
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("{}:{} Read.read", file!(), line!());
         match self.with_context(ContextWaker::Read, |ctx, stream| {
+            #[cfg(not(feature = "no-verbose-logging"))]
             trace!(
                 "{}:{} Read.with_context read -> poll_read",
                 file!(),
@@ -164,8 +167,10 @@ where
     S: AsyncWrite + Unpin,
 {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("{}:{} Write.write", file!(), line!());
         match self.with_context(ContextWaker::Write, |ctx, stream| {
+            #[cfg(not(feature = "no-verbose-logging"))]
             trace!(
                 "{}:{} Write.with_context write -> poll_write",
                 file!(),
@@ -179,8 +184,10 @@ where
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("{}:{} Write.flush", file!(), line!());
         match self.with_context(ContextWaker::Write, |ctx, stream| {
+            #[cfg(not(feature = "no-verbose-logging"))]
             trace!(
                 "{}:{} Write.with_context flush -> poll_flush",
                 file!(),
@@ -198,6 +205,7 @@ pub(crate) fn cvt<T>(r: Result<T, WsError>) -> Poll<Result<T, WsError>> {
     match r {
         Ok(v) => Poll::Ready(Ok(v)),
         Err(WsError::Io(ref e)) if e.kind() == std::io::ErrorKind::WouldBlock => {
+            #[cfg(not(feature = "no-verbose-logging"))]
             trace!("WouldBlock");
             Poll::Pending
         }

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use log::*;
 use std::io::{Read, Write};
 use std::pin::Pin;
@@ -121,7 +122,7 @@ where
     where
         F: FnOnce(&mut Context<'_>, Pin<&mut S>) -> Poll<std::io::Result<R>>,
     {
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("{}:{} AllowStd.with_context", file!(), line!());
         let waker = match kind {
             ContextWaker::Read => task::waker_ref(&self.read_waker_proxy),
@@ -145,10 +146,10 @@ where
     S: AsyncRead + Unpin,
 {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("{}:{} Read.read", file!(), line!());
         match self.with_context(ContextWaker::Read, |ctx, stream| {
-            #[cfg(not(feature = "no-verbose-logging"))]
+            #[cfg(feature = "verbose-logging")]
             trace!(
                 "{}:{} Read.with_context read -> poll_read",
                 file!(),
@@ -167,10 +168,10 @@ where
     S: AsyncWrite + Unpin,
 {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("{}:{} Write.write", file!(), line!());
         match self.with_context(ContextWaker::Write, |ctx, stream| {
-            #[cfg(not(feature = "no-verbose-logging"))]
+            #[cfg(feature = "verbose-logging")]
             trace!(
                 "{}:{} Write.with_context write -> poll_write",
                 file!(),
@@ -184,10 +185,10 @@ where
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("{}:{} Write.flush", file!(), line!());
         match self.with_context(ContextWaker::Write, |ctx, stream| {
-            #[cfg(not(feature = "no-verbose-logging"))]
+            #[cfg(feature = "verbose-logging")]
             trace!(
                 "{}:{} Write.with_context flush -> poll_flush",
                 file!(),
@@ -205,7 +206,7 @@ pub(crate) fn cvt<T>(r: Result<T, WsError>) -> Poll<Result<T, WsError>> {
     match r {
         Ok(v) => Poll::Ready(Ok(v)),
         Err(WsError::Io(ref e)) if e.kind() == std::io::ErrorKind::WouldBlock => {
-            #[cfg(not(feature = "no-verbose-logging"))]
+            #[cfg(feature = "verbose-logging")]
             trace!("WouldBlock");
             Poll::Pending
         }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -43,6 +43,7 @@ where
             .0
             .take()
             .expect("future polled after completion");
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("Setting context when skipping handshake");
         let stream = AllowStd::new(inner.stream, ctx.waker());
 
@@ -129,6 +130,7 @@ where
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         let inner = self.0.take().expect("future polled after completion");
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("Setting ctx when starting handshake");
         let stream = AllowStd::new(inner.stream, ctx.waker());
 
@@ -155,6 +157,7 @@ where
             .expect("future polled after completion");
 
         let machine = s.get_mut();
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("Setting context in handshake");
         machine.get_mut().set_waker(cx.waker());
 

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -1,6 +1,7 @@
 use crate::compat::{AllowStd, SetWaker};
 use crate::WebSocketStream;
 use futures_io::{AsyncRead, AsyncWrite};
+#[allow(unused_imports)]
 use log::*;
 use std::future::Future;
 use std::io::{Read, Write};
@@ -43,7 +44,7 @@ where
             .0
             .take()
             .expect("future polled after completion");
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("Setting context when skipping handshake");
         let stream = AllowStd::new(inner.stream, ctx.waker());
 
@@ -130,7 +131,7 @@ where
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         let inner = self.0.take().expect("future polled after completion");
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("Setting ctx when starting handshake");
         let stream = AllowStd::new(inner.stream, ctx.waker());
 
@@ -157,7 +158,7 @@ where
             .expect("future polled after completion");
 
         let machine = s.get_mut();
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("Setting context in handshake");
         machine.get_mut().set_waker(cx.waker());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,7 @@ impl<S> WebSocketStream<S> {
         F: FnOnce(&mut WebSocket<AllowStd<S>>) -> R,
         AllowStd<S>: Read + Write,
     {
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("{}:{} WebSocketStream.with_context", file!(), line!());
         if let Some((kind, ctx)) = ctx {
             self.inner.get_mut().set_waker(kind, &ctx.waker());
@@ -305,8 +306,10 @@ where
     type Item = Result<Message, WsError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        #[cfg(not(feature = "no-verbose-logging"))]
         trace!("{}:{} Stream.poll_next", file!(), line!());
         match futures_util::ready!(self.with_context(Some((ContextWaker::Read, cx)), |s| {
+            #[cfg(not(feature = "no-verbose-logging"))]
             trace!(
                 "{}:{} Stream.with_context poll_next -> read_message()",
                 file!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ impl<S> WebSocketStream<S> {
         F: FnOnce(&mut WebSocket<AllowStd<S>>) -> R,
         AllowStd<S>: Read + Write,
     {
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("{}:{} WebSocketStream.with_context", file!(), line!());
         if let Some((kind, ctx)) = ctx {
             self.inner.get_mut().set_waker(kind, &ctx.waker());
@@ -306,10 +306,10 @@ where
     type Item = Result<Message, WsError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        #[cfg(not(feature = "no-verbose-logging"))]
+        #[cfg(feature = "verbose-logging")]
         trace!("{}:{} Stream.poll_next", file!(), line!());
         match futures_util::ready!(self.with_context(Some((ContextWaker::Read, cx)), |s| {
-            #[cfg(not(feature = "no-verbose-logging"))]
+            #[cfg(feature = "verbose-logging")]
             trace!(
                 "{}:{} Stream.with_context poll_next -> read_message()",
                 file!(),


### PR DESCRIPTION
This PR adds a feature `no-verbose-logging` that disables most of the logging, to elimate verbose loggings on hotpath. 
Additionally, even disabled from logging crates, verbose logging causes serious performance loss.

https://github.com/sdroege/async-tungstenite/issues/89
https://github.com/snapview/tungstenite-rs/pull/211