### PR TITLE
Fix the unreachable test url

### DIFF
--- a/examples/async-std-echo.rs
+++ b/examples/async-std-echo.rs
@@ -5,11 +5,15 @@ use async_std::task;
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(any(feature = "async-tls", feature = "async-native-tls"))]
-    let url = "wss://echo.websocket.org";
+    let url = "wss://echo.websocket.events/.ws";
     #[cfg(not(any(feature = "async-tls", feature = "async-native-tls")))]
-    let url = "ws://echo.websocket.org";
+    let url = "ws://echo.websocket.events/.ws";
 
+    println!("Connecting: \"{}\"", url);
     let (mut ws_stream, _) = connect_async(url).await?;
+
+    let msg = ws_stream.next().await.ok_or("didn't receive anything")??;
+    println!("Received: {:?}", msg);
 
     let text = "Hello, World!";
 


### PR DESCRIPTION
I found a new test URL but we need to receive a sponsorship message first when establishing a connection.

> https://www.lob.com/blog/websocket-org-is-down-here-is-an-alternative