### PR TITLE
Add a GIO version of accept_async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,10 @@ name = "gio-echo"
 required-features = ["gio-runtime"]
 
 [[example]]
+name = "gio-echo-server"
+required-features = ["gio-runtime"]
+
+[[example]]
 name = "tokio-echo"
 required-features = ["tokio-runtime"]
 

--- a/examples/gio-echo-server.rs
+++ b/examples/gio-echo-server.rs
@@ -1,0 +1,64 @@
+use std::{env, net::SocketAddr};
+
+use async_tungstenite::{
+    gio::accept_async,
+    tungstenite::{Error, Result},
+};
+use futures::prelude::*;
+use gio::{
+    prelude::*, InetSocketAddress, SocketConnection, SocketProtocol, SocketService, SocketType,
+};
+use log::info;
+
+async fn accept_connection(stream: SocketConnection) -> Result<()> {
+    let addr = stream
+        .socket()
+        .remote_address()
+        .expect("SocketConnection should have a remote address");
+
+    println!("Peer address: {}", addr);
+    let mut ws_stream = accept_async(stream)
+        .await
+        .expect("Error during the websocket handshake occurred");
+
+    while let Some(msg) = ws_stream.next().await {
+        let msg = msg?;
+        if msg.is_text() || msg.is_binary() {
+            ws_stream.send(msg).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = env_logger::try_init();
+    let addr = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:8080".to_string());
+
+    let sockaddr: SocketAddr = addr.parse()?;
+    let inetaddr: InetSocketAddress = sockaddr.into();
+
+    let service = SocketService::new();
+    service.add_address(
+        &inetaddr,
+        SocketType::Stream,
+        SocketProtocol::Tcp,
+        glib::Object::NONE,
+    )?;
+    println!("Listening on: {}", inetaddr);
+
+    service.connect_incoming(|_service, connection, _| {
+        let stream = connection.clone();
+        glib::MainContext::default().spawn_local(async move {
+            accept_connection(stream).await;
+        });
+        false
+    });
+
+    let main_loop = glib::MainLoop::new(None, false);
+    main_loop.run();
+
+    Ok(())
+}

--- a/examples/gio-echo.rs
+++ b/examples/gio-echo.rs
@@ -15,6 +15,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Received: {:?}", msg);
 
+    ws_stream.close(None).await.expect("error sending close");
+
     Ok(())
 }
 


### PR DESCRIPTION
Just like we have `accept_async` for tokio and async_std, we can build one for GIO so we can use something like `gio::SocketService` to handle the accepting and then we can spawn off tasks.

This comes also with a sample server just to make sure it can work.