### PR TITLE
Update tungstenite dependency to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ futures-io = { version = "0.3", default-features = false, features = ["std"] }
 pin-project-lite = "0.2"
 
 [dependencies.tungstenite]
-version = "0.23"
+version = "0.24"
 default-features = false
 
 [dependencies.async-std]
@@ -124,7 +124,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
 
 [dev-dependencies.tungstenite]
-version = "0.23"
+version = "0.24"
 features = ["url"]
 
 [[example]]


### PR DESCRIPTION
This PR updates the dependency on tungstenite from version 0.23 to 0.24.