### PR TITLE
fix: waker_ref and ArcWake only available on alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ features = ["async-std-runtime", "tokio-runtime", "gio-runtime", "async-tls", "a
 [dependencies]
 log = "0.4"
 futures-core = { version = "0.3", default-features = false }
-futures-task = { version = "0.3.31", default-features = false }
+futures-task = { version = "0.3.31", default-features = false, features = ["alloc"] }
 atomic-waker = { version = "1.1", default-features = false }
 futures-io = { version = "0.3", default-features = false, features = ["std"] }
 pin-project-lite = "0.2"


### PR DESCRIPTION
I'm using `async-tungstenite` as dependency and my builds recently started failing. I get the following error message:

```
error[E0432]: unresolved imports `futures_task::waker_ref`, `futures_task::ArcWake`
  --> /home/emma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-tungstenite-0.28.1/src/compat.rs:9:20
   |
9  | use futures_task::{waker_ref, ArcWake};
   |                    ^^^^^^^^^  ^^^^^^^ no `ArcWake` in the root
   |                    |
   |                    no `waker_ref` in the root
   |
note: found an item that was configured out
  --> /home/emma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-task-0.3.31/src/lib.rs:37:5
   |
37 | mod waker_ref;
   |     ^^^^^^^^^
note: the item is gated behind the `alloc` feature
  --> /home/emma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-task-0.3.31/src/lib.rs:36:7
   |
36 | #[cfg(feature = "alloc")]
   |       ^^^^^^^^^^^^^^^^^
note: found an item that was configured out
  --> /home/emma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-task-0.3.31/src/lib.rs:40:28
   |
40 | pub use crate::waker_ref::{waker_ref, WakerRef};
   |                            ^^^^^^^^^
note: the item is gated behind the `alloc` feature
  --> /home/emma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-task-0.3.31/src/lib.rs:39:7
   |
39 | #[cfg(feature = "alloc")]
   |       ^^^^^^^^^^^^^^^^^
note: found an item that was configured out
  --> /home/emma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-task-0.3.31/src/lib.rs:26:26
   |
26 | pub use crate::arc_wake::ArcWake;
   |                          ^^^^^^^
note: the item is gated behind the `alloc` feature
  --> /home/emma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-task-0.3.31/src/lib.rs:25:7
   |
25 | #[cfg(feature = "alloc")]
   |       ^^^^^^^^^^^^^^^^^
```

Weirdly enough I could not reproduce this by compiling `async-tungstenite` (with `--no-default-features`). But creating a new crate with the following will produce the error:

```toml
async-tungstenite = { version = "0.28.1", default-features = false }
```

and adding another dependency to enable the feature will fix it:

```toml
futures-task = { version = "0.3.31", default-features = false, features = ["alloc"] }
```

Looking at the source code of `futures-task`, `waker_ref` and `ArcWake` indeed require the `alloc` feature to be enabled. This PR fixes this.
