### PR TITLE
Update webpki-roots to 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ version = "0.8"
 
 [dependencies.webpki-roots]
 optional = true
-version = "0.26"
+version = "1.0"
 
 [dependencies.gio]
 optional = true


### PR DESCRIPTION
This is not a semver-major change, since this crate doesn't reexport anything from webpki-roots.