### PR TITLE
Add `WebSocketStream::split` method

### DIFF
--- a/examples/client-bytes.rs
+++ b/examples/client-bytes.rs
@@ -12,8 +12,6 @@
 
 use std::env;
 
-use futures::StreamExt;
-
 use async_std::io;
 use async_std::task;
 use async_tungstenite::async_std::connect_async;

--- a/examples/interval-server.rs
+++ b/examples/interval-server.rs
@@ -22,7 +22,7 @@ async fn accept_connection(peer: SocketAddr, stream: TcpStream) {
 async fn handle_connection(peer: SocketAddr, stream: TcpStream) -> Result<()> {
     let ws_stream = accept_async(stream).await.expect("Failed to accept");
     info!("New WebSocket connection: {}", peer);
-    let (mut ws_sender, mut ws_receiver) = ws_stream.split();
+    let (ws_sender, mut ws_receiver) = ws_stream.split();
     let mut interval = async_std::stream::interval(Duration::from_millis(1000));
 
     // Echo incoming WebSocket messages and send a message periodically every second.

--- a/examples/tokio-client-bytes.rs
+++ b/examples/tokio-client-bytes.rs
@@ -12,8 +12,6 @@
 
 use std::env;
 
-use futures::StreamExt;
-
 use async_tungstenite::tokio::connect_async;
 use async_tungstenite::{ByteReader, ByteWriter};
 use tokio::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ struct Send<W> {
 }
 
 /// Performs an asynchronous message send to the websocket.
-fn send<S>(
+fn send_helper<S>(
     ws: &mut WebSocketStream<S>,
     msg: &mut Option<Message>,
     cx: &mut Context<'_>,
@@ -532,7 +532,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.get_mut();
-        send(me.ws, &mut me.msg, cx)
+        send_helper(me.ws, &mut me.msg, cx)
     }
 }
 
@@ -545,7 +545,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.get_mut();
         let mut ws = me.ws.lock();
-        send(&mut ws, &mut me.msg, cx)
+        send_helper(&mut ws, &mut me.msg, cx)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,7 @@ where
             })
     }
 
+    #[cfg(feature = "futures-03-sink")]
     fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), WsError>> {
         self.ready = true;
         let res = if self.closing {

--- a/tests/communication.rs
+++ b/tests/communication.rs
@@ -101,7 +101,7 @@ async fn split_communication() {
         .await
         .expect("Client failed to connect");
 
-    let (mut tx, _rx) = futures::StreamExt::split(stream);
+    let (tx, _rx) = stream.split();
 
     for i in 1..10 {
         info!("Sending message");
@@ -110,7 +110,7 @@ async fn split_communication() {
             .expect("Failed to send message");
     }
 
-    tx.close().await.expect("Failed to close");
+    tx.close(None).await.expect("Failed to close");
 
     info!("Waiting for response messages");
     let messages = msg_rx.await.expect("Failed to receive messages");

--- a/tests/communication.rs
+++ b/tests/communication.rs
@@ -100,7 +100,8 @@ async fn split_communication() {
     let (stream, _) = client_async(url, tcp)
         .await
         .expect("Client failed to connect");
-    let (mut tx, _rx) = stream.split();
+
+    let (mut tx, _rx) = futures::StreamExt::split(stream);
 
     for i in 1..10 {
         info!("Sending message");

--- a/tests/communication.rs
+++ b/tests/communication.rs
@@ -116,3 +116,53 @@ async fn split_communication() {
     let messages = msg_rx.await.expect("Failed to receive messages");
     assert_eq!(messages.len(), 10);
 }
+
+#[async_std::test]
+async fn concurrent_send() {
+    let _ = env_logger::try_init();
+
+    let (con_tx, con_rx) = futures::channel::oneshot::channel();
+    let (msg_tx, msg_rx) = futures::channel::oneshot::channel();
+
+    let f = async move {
+        let listener = TcpListener::bind("127.0.0.1:12347").await.unwrap();
+        info!("Server ready");
+        con_tx.send(()).unwrap();
+        info!("Waiting on next connection");
+        let (connection, _) = listener.accept().await.expect("No connections to accept");
+        let stream = accept_async(connection).await;
+        let stream = stream.expect("Failed to handshake with connection");
+        run_connection(stream, msg_tx).await;
+    };
+
+    task::spawn(f);
+
+    info!("Waiting for server to be ready");
+
+    con_rx.await.expect("Server not ready");
+    let tcp = TcpStream::connect("127.0.0.1:12347")
+        .await
+        .expect("Failed to connect");
+    let url = url::Url::parse("ws://localhost:12347/").unwrap();
+    let (stream, _) = client_async(url, tcp)
+        .await
+        .expect("Client failed to connect");
+
+    let (tx, _rx) = stream.split();
+
+    // the `WebSocketSender::send` takes a shared `&self`, so you can call it concurrently.
+    // this test case checks that it works
+    let results = futures::future::join_all((1..10).map(|i| {
+        info!("Sending message");
+        tx.send(Message::text(format!("{}", i)))
+    }))
+    .await;
+
+    assert!(results.iter().all(Result::is_ok));
+
+    tx.close(None).await.expect("Failed to close");
+
+    info!("Waiting for response messages");
+    let messages = msg_rx.await.expect("Failed to receive messages");
+    assert_eq!(messages.len(), 10);
+}


### PR DESCRIPTION
Implements #155

The current implementation is simple - it's an `Arc<Mutex<_>>`. Some optimizations might be possible in the future. I also did some minor refactoring to de-duplicate code during the process.

I'll write an integration with the `ByteWriter` type later, if this PR will be ok.