### PR TITLE
examples/tests: Move from async-std to smol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ futures = "0.3"
 url = "2.0.0"
 env_logger = ">= 0.10, <= 0.11"
 async-std = { version = "1.0", features = ["attributes", "unstable"] }
+smol = "2.0"
 tokio = { version = "1.0", features = ["full"] }
 futures-channel = "0.3"
 hyper = { version = "1.0", default-features = false, features = ["http1", "server"] }
@@ -147,14 +148,9 @@ http-body-util = "0.1"
 version = "0.29"
 features = ["url"]
 
-# For smol examples
-[dependencies.smol]
-optional = true
-version = "2.0"
-
 [[example]]
 name = "autobahn-client"
-required-features = ["async-std-runtime"]
+required-features = ["smol-runtime"]
 
 [[example]]
 name = "async-std-echo"
@@ -162,35 +158,35 @@ required-features = ["async-std-runtime"]
 
 [[example]]
 name = "smol-echo"
-required-features = ["smol-runtime", "smol"]
+required-features = ["smol-runtime"]
 
 [[example]]
 name = "client"
-required-features = ["async-std-runtime"]
+required-features = ["smol-runtime"]
 
 [[example]]
 name = "client-bytes"
-required-features = ["async-std-runtime"]
+required-features = ["smol-runtime"]
 
 [[example]]
 name = "autobahn-server"
-required-features = ["async-std-runtime", "futures-03-sink"]
+required-features = ["smol-runtime", "futures-03-sink"]
 
 [[example]]
 name = "server"
-required-features = ["async-std-runtime"]
+required-features = ["smol-runtime"]
 
 [[example]]
 name = "echo-server"
-required-features = ["async-std-runtime"]
+required-features = ["smol-runtime"]
 
 [[example]]
 name = "server-headers"
-required-features = ["async-std-runtime", "handshake", "futures-util"]
+required-features = ["smol-runtime", "handshake", "futures-util"]
 
 [[example]]
 name = "interval-server"
-required-features = ["async-std-runtime"]
+required-features = ["smol-runtime"]
 
 [[example]]
 name = "gio-echo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ version = "0.22"
 futures = "0.3"
 url = "2.0.0"
 env_logger = ">= 0.10, <= 0.11"
-async-std = { version = "1.0", features = ["attributes", "unstable"] }
 smol = "2.0"
 tokio = { version = "1.0", features = ["full"] }
 futures-channel = "0.3"

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -1,4 +1,4 @@
-use async_tungstenite::{async_std::connect_async, tungstenite::Error, tungstenite::Result};
+use async_tungstenite::{smol::connect_async, tungstenite::Error, tungstenite::Result};
 use futures::prelude::*;
 use log::*;
 
@@ -58,5 +58,5 @@ async fn run() {
 }
 
 fn main() {
-    async_std::task::block_on(run());
+    smol::block_on(run());
 }

--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -1,10 +1,10 @@
-use async_std::net::{SocketAddr, TcpListener, TcpStream};
 use async_tungstenite::{
     accept_async,
     tungstenite::{Error, Result},
 };
 use futures::prelude::*;
 use log::*;
+use smol::net::{SocketAddr, TcpListener, TcpStream};
 
 async fn accept_connection(peer: SocketAddr, stream: TcpStream) {
     if let Err(e) = handle_connection(peer, stream).await {
@@ -45,10 +45,10 @@ async fn run() {
             .expect("connected streams should have a peer address");
         info!("Peer address: {}", peer);
 
-        async_std::task::spawn(accept_connection(peer, stream));
+        smol::spawn(accept_connection(peer, stream)).detach();
     }
 }
 
 fn main() {
-    async_std::task::block_on(run());
+    smol::block_on(run());
 }

--- a/examples/client-bytes.rs
+++ b/examples/client-bytes.rs
@@ -12,10 +12,11 @@
 
 use std::env;
 
-use async_std::io;
-use async_std::task;
-use async_tungstenite::async_std::connect_async;
+use async_tungstenite::smol::connect_async;
 use async_tungstenite::{ByteReader, ByteWriter};
+
+use smol::io::AsyncWriteExt;
+use smol::Unblock;
 
 async fn run() {
     let connect_addr = env::args()
@@ -28,14 +29,25 @@ async fn run() {
     println!("WebSocket handshake has been successfully completed");
 
     let (write, read) = ws_stream.split();
-    let byte_writer = ByteWriter::new(write);
-    let byte_reader = ByteReader::new(read);
-    let stdin_to_ws = task::spawn(io::copy(io::stdin(), byte_writer));
-    let ws_to_stdout = task::spawn(io::copy(byte_reader, io::stdout()));
+
+    let stdin_to_ws: smol::Task<std::io::Result<()>> = smol::spawn(async {
+        let mut stdin = Unblock::new(std::io::stdin());
+        let mut byte_writer = ByteWriter::new(write);
+        smol::io::copy(&mut stdin, &mut byte_writer).await?;
+        byte_writer.flush().await
+    });
+
+    let ws_to_stdout: smol::Task<std::io::Result<()>> = smol::spawn(async {
+        let mut byte_reader = ByteReader::new(read);
+        let mut stdout = Unblock::new(std::io::stdout());
+        smol::io::copy(&mut byte_reader, &mut stdout).await?;
+        stdout.flush().await
+    });
+
     stdin_to_ws.await.unwrap();
     ws_to_stdout.await.unwrap();
 }
 
 fn main() {
-    task::block_on(run())
+    smol::block_on(run())
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -14,11 +14,9 @@ use std::env;
 
 use futures::{future, pin_mut, StreamExt};
 
-use async_std::io;
-use async_std::prelude::*;
-use async_std::task;
-use async_tungstenite::async_std::connect_async;
+use async_tungstenite::smol::connect_async;
 use async_tungstenite::tungstenite::protocol::Message;
+use smol::io::{AsyncReadExt, AsyncWriteExt};
 
 async fn run() {
     let connect_addr = env::args()
@@ -26,7 +24,7 @@ async fn run() {
         .unwrap_or_else(|| panic!("this program requires at least one argument"));
 
     let (stdin_tx, stdin_rx) = futures::channel::mpsc::unbounded();
-    task::spawn(read_stdin(stdin_tx));
+    smol::spawn(read_stdin(stdin_tx)).detach();
 
     let (ws_stream, _) = connect_async(&connect_addr)
         .await
@@ -39,7 +37,9 @@ async fn run() {
     let ws_to_stdout = {
         read.for_each(|message| async {
             let data = message.unwrap().into_data();
-            async_std::io::stdout().write_all(&data).await.unwrap();
+            let mut stdout = smol::Unblock::new(std::io::stdout());
+            stdout.write_all(&data).await.unwrap();
+            stdout.flush().await.unwrap();
         })
     };
 
@@ -50,7 +50,7 @@ async fn run() {
 // Our helper method which will read data from stdin and send it along the
 // sender provided.
 async fn read_stdin(tx: futures::channel::mpsc::UnboundedSender<Message>) {
-    let mut stdin = io::stdin();
+    let mut stdin = smol::Unblock::new(std::io::stdin());
     loop {
         let mut buf = vec![0; 1024];
         let n = match stdin.read(&mut buf).await {
@@ -63,5 +63,5 @@ async fn read_stdin(tx: futures::channel::mpsc::UnboundedSender<Message>) {
 }
 
 fn main() {
-    task::block_on(run())
+    smol::block_on(run())
 }

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -2,18 +2,17 @@
 //!
 //! You can test this out by running:
 //!
-//!     cargo run --features="async-std-runtime" --example echo-server 127.0.0.1:12345
+//!     cargo run --features="smol-runtime" --example echo-server 127.0.0.1:12345
 //!
 //! And then in another window run:
 //!
-//!     cargo run --features="async-std-runtime" --example client ws://127.0.0.1:12345/
+//!     cargo run --features="smol-runtime" --example client ws://127.0.0.1:12345/
 
 use std::{env, io::Error};
 
-use async_std::net::{TcpListener, TcpStream};
-use async_std::task;
 use futures::prelude::*;
 use log::info;
+use smol::net::{TcpListener, TcpStream};
 
 async fn run() -> Result<(), Error> {
     let _ = env_logger::try_init();
@@ -27,7 +26,7 @@ async fn run() -> Result<(), Error> {
     info!("Listening on: {}", addr);
 
     while let Ok((stream, _)) = listener.accept().await {
-        task::spawn(accept_connection(stream));
+        smol::spawn(accept_connection(stream)).detach();
     }
 
     Ok(())
@@ -48,11 +47,12 @@ async fn accept_connection(stream: TcpStream) {
     let (write, read) = ws_stream.split();
     // We should not forward messages other than text or binary.
     read.try_filter(|msg| future::ready(msg.is_text() || msg.is_binary()))
+        .inspect(|msg| info!("Forwarding message: {:?}", msg))
         .forward(write)
         .await
         .expect("Failed to forward messages")
 }
 
 fn main() -> Result<(), Error> {
-    task::block_on(run())
+    smol::block_on(run())
 }

--- a/examples/interval-server.rs
+++ b/examples/interval-server.rs
@@ -1,5 +1,3 @@
-use async_std::net::{TcpListener, TcpStream};
-use async_std::task;
 use async_tungstenite::{
     accept_async,
     tungstenite::{Error, Message, Result},
@@ -7,6 +5,7 @@ use async_tungstenite::{
 use futures::future::{select, Either};
 use futures::prelude::*;
 use log::*;
+use smol::net::{TcpListener, TcpStream};
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -23,7 +22,7 @@ async fn handle_connection(peer: SocketAddr, stream: TcpStream) -> Result<()> {
     let ws_stream = accept_async(stream).await.expect("Failed to accept");
     info!("New WebSocket connection: {}", peer);
     let (mut ws_sender, mut ws_receiver) = ws_stream.split();
-    let mut interval = async_std::stream::interval(Duration::from_millis(1000));
+    let mut interval = smol::Timer::interval(Duration::from_millis(1000));
 
     // Echo incoming WebSocket messages and send a message periodically every second.
 
@@ -70,10 +69,10 @@ async fn run() {
             .expect("connected streams should have a peer address");
         info!("Peer address: {}", peer);
 
-        task::spawn(accept_connection(peer, stream));
+        smol::spawn(accept_connection(peer, stream)).detach();
     }
 }
 
 fn main() {
-    task::block_on(run());
+    smol::block_on(run());
 }

--- a/examples/server-headers.rs
+++ b/examples/server-headers.rs
@@ -9,10 +9,6 @@
 //! ```sh
 //! cmd /c "set RUST_LOG=debug && cargo run --example server-headers"
 //! ```
-use async_std::{
-    net::{TcpListener, TcpStream},
-    task,
-};
 use async_tungstenite::{
     accept_hdr_async,
     tungstenite::{
@@ -21,26 +17,29 @@ use async_tungstenite::{
         Message,
     },
 };
+use smol::net::{TcpListener, TcpStream};
 use url::Url;
 #[macro_use]
 extern crate log;
 use futures_util::StreamExt;
 
-#[async_std::main]
-async fn main() {
-    env_logger::builder().format_timestamp(None).init();
+fn main() {
+    smol::block_on(async {
+        env_logger::builder().format_timestamp(None).init();
 
-    task::spawn(async move {
-        server().await;
+        smol::spawn(async move {
+            server().await;
+        })
+        .detach();
+        client();
     });
-    client();
 }
 
 async fn server() {
     let server = TcpListener::bind("127.0.0.1:8080").await.unwrap();
 
     while let Ok((stream, _)) = server.accept().await {
-        task::spawn(accept_connection(stream));
+        smol::spawn(accept_connection(stream)).detach();
     }
 }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -6,11 +6,11 @@
 //!
 //! You can test this out by running:
 //!
-//!     cargo run --features="async-std-runtime" --example server 127.0.0.1:12345
+//!     cargo run --features="smol-runtime" --example server 127.0.0.1:12345
 //!
 //! And then in another window run:
 //!
-//!     cargo run --features="async-std-runtime" --example client ws://127.0.0.1:12345/
+//!     cargo run --features="smol-runtime" --example client ws://127.0.0.1:12345/
 //!
 //! You can run the second command in multiple windows and then chat between the
 //! two, seeing the messages from the other client as they're received. For all
@@ -31,9 +31,8 @@ use futures::{
     future, pin_mut,
 };
 
-use async_std::net::{TcpListener, TcpStream};
-use async_std::task;
 use async_tungstenite::tungstenite::protocol::Message;
+use smol::net::{TcpListener, TcpStream};
 
 type Tx = UnboundedSender<Message>;
 type PeerMap = Arc<Mutex<HashMap<SocketAddr, Tx>>>;
@@ -102,12 +101,12 @@ async fn run() -> Result<(), IoError> {
 
     // Let's spawn the handling of each connection in a separate task.
     while let Ok((stream, addr)) = listener.accept().await {
-        task::spawn(handle_connection(state.clone(), stream, addr));
+        smol::spawn(handle_connection(state.clone(), stream, addr)).detach();
     }
 
     Ok(())
 }
 
 fn main() -> Result<(), IoError> {
-    task::block_on(run())
+    smol::block_on(run())
 }

--- a/scripts/autobahn-client.sh
+++ b/scripts/autobahn-client.sh
@@ -32,5 +32,5 @@ docker run -d --rm \
     wstest -m fuzzingserver -s 'autobahn/fuzzingserver.json'
 
 sleep 5
-cargo run --release --features async-std-runtime --example autobahn-client
+cargo run --release --features smol-runtime --example autobahn-client
 test_diff

--- a/scripts/autobahn-server.sh
+++ b/scripts/autobahn-server.sh
@@ -22,7 +22,7 @@ function test_diff() {
     fi
 }
 
-cargo run --release --features async-std-runtime --example autobahn-server & WSSERVER_PID=$!
+cargo run --release --features smol-runtime --example autobahn-server & WSSERVER_PID=$!
 sleep 5
 
 docker run --rm \

--- a/tests/communication.rs
+++ b/tests/communication.rs
@@ -1,10 +1,9 @@
 #![cfg(feature = "handshake")]
 
-use async_std::net::{TcpListener, TcpStream};
-use async_std::task;
 use async_tungstenite::{accept_async, client_async, WebSocketStream};
 use futures::prelude::*;
 use log::*;
+use smol::net::{TcpListener, TcpStream};
 use tungstenite::Message;
 
 async fn run_connection<S>(
@@ -24,99 +23,107 @@ async fn run_connection<S>(
     msg_tx.send(messages).expect("Failed to send results");
 }
 
-#[async_std::test]
-async fn communication() {
-    let _ = env_logger::try_init();
+#[test]
+fn communication() {
+    let test = async {
+        let _ = env_logger::try_init();
 
-    let (con_tx, con_rx) = futures::channel::oneshot::channel();
-    let (msg_tx, msg_rx) = futures::channel::oneshot::channel();
+        let (con_tx, con_rx) = futures::channel::oneshot::channel();
+        let (msg_tx, msg_rx) = futures::channel::oneshot::channel();
 
-    let f = async move {
-        let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
-        info!("Server ready");
-        con_tx.send(()).unwrap();
-        info!("Waiting on next connection");
-        let (connection, _) = listener.accept().await.expect("No connections to accept");
-        let stream = accept_async(connection).await;
-        let stream = stream.expect("Failed to handshake with connection");
-        run_connection(stream, msg_tx).await;
+        let f = async move {
+            let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
+            info!("Server ready");
+            con_tx.send(()).unwrap();
+            info!("Waiting on next connection");
+            let (connection, _) = listener.accept().await.expect("No connections to accept");
+            let stream = accept_async(connection).await;
+            let stream = stream.expect("Failed to handshake with connection");
+            run_connection(stream, msg_tx).await;
+        };
+
+        smol::spawn(f).detach();
+
+        info!("Waiting for server to be ready");
+
+        con_rx.await.expect("Server not ready");
+        let tcp = TcpStream::connect("127.0.0.1:12345")
+            .await
+            .expect("Failed to connect");
+        let url = "ws://localhost:12345/";
+        let (mut stream, _) = client_async(url, tcp)
+            .await
+            .expect("Client failed to connect");
+
+        for i in 1..10 {
+            info!("Sending message");
+            stream
+                .send(Message::text(format!("{}", i)))
+                .await
+                .expect("Failed to send message");
+        }
+
+        stream.close(None).await.expect("Failed to close");
+
+        info!("Waiting for response messages");
+        let messages = msg_rx.await.expect("Failed to receive messages");
+        assert_eq!(messages.len(), 10);
     };
 
-    task::spawn(f);
-
-    info!("Waiting for server to be ready");
-
-    con_rx.await.expect("Server not ready");
-    let tcp = TcpStream::connect("127.0.0.1:12345")
-        .await
-        .expect("Failed to connect");
-    let url = "ws://localhost:12345/";
-    let (mut stream, _) = client_async(url, tcp)
-        .await
-        .expect("Client failed to connect");
-
-    for i in 1..10 {
-        info!("Sending message");
-        stream
-            .send(Message::text(format!("{}", i)))
-            .await
-            .expect("Failed to send message");
-    }
-
-    stream.close(None).await.expect("Failed to close");
-
-    info!("Waiting for response messages");
-    let messages = msg_rx.await.expect("Failed to receive messages");
-    assert_eq!(messages.len(), 10);
+    smol::block_on(test);
 }
 
-#[async_std::test]
-async fn split_communication() {
-    let _ = env_logger::try_init();
+#[test]
+fn split_communication() {
+    let test = async {
+        let _ = env_logger::try_init();
 
-    let (con_tx, con_rx) = futures::channel::oneshot::channel();
-    let (msg_tx, msg_rx) = futures::channel::oneshot::channel();
+        let (con_tx, con_rx) = futures::channel::oneshot::channel();
+        let (msg_tx, msg_rx) = futures::channel::oneshot::channel();
 
-    let f = async move {
-        let listener = TcpListener::bind("127.0.0.1:12346").await.unwrap();
-        info!("Server ready");
-        con_tx.send(()).unwrap();
-        info!("Waiting on next connection");
-        let (connection, _) = listener.accept().await.expect("No connections to accept");
-        let stream = accept_async(connection).await;
-        let stream = stream.expect("Failed to handshake with connection");
-        run_connection(stream, msg_tx).await;
+        let f = async move {
+            let listener = TcpListener::bind("127.0.0.1:12346").await.unwrap();
+            info!("Server ready");
+            con_tx.send(()).unwrap();
+            info!("Waiting on next connection");
+            let (connection, _) = listener.accept().await.expect("No connections to accept");
+            let stream = accept_async(connection).await;
+            let stream = stream.expect("Failed to handshake with connection");
+            run_connection(stream, msg_tx).await;
+        };
+
+        smol::spawn(f).detach();
+
+        info!("Waiting for server to be ready");
+
+        con_rx.await.expect("Server not ready");
+        let tcp = TcpStream::connect("127.0.0.1:12346")
+            .await
+            .expect("Failed to connect");
+        let url = url::Url::parse("ws://localhost:12346/").unwrap();
+        let (stream, _) = client_async(url, tcp)
+            .await
+            .expect("Client failed to connect");
+
+        let (mut tx, rx) = stream.split();
+
+        for i in 1..10 {
+            info!("Sending message");
+            tx.send(Message::text(format!("{}", i)))
+                .await
+                .expect("Failed to send message");
+        }
+
+        tx.close(None).await.expect("Failed to close");
+
+        info!("Waiting for response messages");
+        let messages = msg_rx.await.expect("Failed to receive messages");
+        assert_eq!(messages.len(), 10);
+
+        assert!(tx.is_pair_of(&rx));
+        assert!(rx.is_pair_of(&tx));
+        WebSocketStream::reunite(tx, rx).expect("Failed to reunite the stream");
     };
 
-    task::spawn(f);
-
-    info!("Waiting for server to be ready");
-
-    con_rx.await.expect("Server not ready");
-    let tcp = TcpStream::connect("127.0.0.1:12346")
-        .await
-        .expect("Failed to connect");
-    let url = url::Url::parse("ws://localhost:12346/").unwrap();
-    let (stream, _) = client_async(url, tcp)
-        .await
-        .expect("Client failed to connect");
-
-    let (mut tx, rx) = stream.split();
-
-    for i in 1..10 {
-        info!("Sending message");
-        tx.send(Message::text(format!("{}", i)))
-            .await
-            .expect("Failed to send message");
-    }
-
-    tx.close(None).await.expect("Failed to close");
-
-    info!("Waiting for response messages");
-    let messages = msg_rx.await.expect("Failed to receive messages");
-    assert_eq!(messages.len(), 10);
-
-    assert!(tx.is_pair_of(&rx));
-    assert!(rx.is_pair_of(&tx));
-    WebSocketStream::reunite(tx, rx).expect("Failed to reunite the stream");
+    smol::block_on(test);
 }

--- a/tests/handshakes.rs
+++ b/tests/handshakes.rs
@@ -1,30 +1,32 @@
 #![cfg(feature = "handshake")]
 
-use async_std::net::{TcpListener, TcpStream};
-use async_std::task;
 use async_tungstenite::{accept_async, client_async};
+use smol::net::{TcpListener, TcpStream};
 
-#[async_std::test]
-async fn handshakes() {
-    let (tx, rx) = futures::channel::oneshot::channel();
+#[test]
+fn handshakes() {
+    let test = async {
+        let (tx, rx) = futures::channel::oneshot::channel();
 
-    let f = async move {
-        let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
-        tx.send(()).unwrap();
-        while let Ok((connection, _)) = listener.accept().await {
-            let stream = accept_async(connection).await;
-            stream.expect("Failed to handshake with connection");
-        }
+        let f = async move {
+            let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
+            tx.send(()).unwrap();
+            while let Ok((connection, _)) = listener.accept().await {
+                let stream = accept_async(connection).await;
+                stream.expect("Failed to handshake with connection");
+            }
+        };
+
+        smol::spawn(f).detach();
+
+        rx.await.expect("Failed to wait for server to be ready");
+        let tcp = TcpStream::connect("127.0.0.1:12345")
+            .await
+            .expect("Failed to connect");
+        let url = url::Url::parse("ws://localhost:12345/").unwrap();
+        let _stream = client_async(url, tcp)
+            .await
+            .expect("Client failed to connect");
     };
-
-    task::spawn(f);
-
-    rx.await.expect("Failed to wait for server to be ready");
-    let tcp = TcpStream::connect("127.0.0.1:12345")
-        .await
-        .expect("Failed to connect");
-    let url = url::Url::parse("ws://localhost:12345/").unwrap();
-    let _stream = client_async(url, tcp)
-        .await
-        .expect("Client failed to connect");
+    smol::block_on(test);
 }


### PR DESCRIPTION
This should finish up the smol migration by moving all examples (except for `async-std-echo`) and tests from async-std to smol.

Some examples have been reworked because of differing drop semantics. `smol::Unblock` will not flush buffers synchronously on `Drop::drop()` anymore, which in turn requires us to add `flush()` calls in some places. I have tested the examples as best as I could but I might as well have overlooked something.